### PR TITLE
fix: rebuilt for npm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 See [Microsoft's Change log](https://github.com/microsoft/SEAL/blob/master/Changes.md)
 for more details on each SEAL version change.
 
+## Version 3.0.3
+
+Fix:
+- Latest bundle for npm was not built correctly. Rebuilt with exception handling
+  and the other changes.
+
 ## Version 3.0.2
 
 Feat:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-seal",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Microsoft SEAL in Javascript",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Latest build on npm for 3.0.2 was not updated properly. This new version updates the npm package to bring it up to date.